### PR TITLE
Recent versions of Leaflet do not have L.Polygon and L.MultiPolygon classes

### DIFF
--- a/leaflet-pip.js
+++ b/leaflet-pip.js
@@ -12,8 +12,9 @@ var leafletPip = {
 
         layer.eachLayer(function(l) {
             if (first && results.length) return;
-            if ((l instanceof L.MultiPolygon ||
-                 l instanceof L.Polygon) &&
+            console.log(l);
+            if ((l.feature.geometry.type === "MultiPolygon" ||
+                 l.feature.geometry.type === "Polygon") &&
                 gju.pointInPolygon({
                     type: 'Point',
                     coordinates: p

--- a/leaflet-pip.js
+++ b/leaflet-pip.js
@@ -12,7 +12,6 @@ var leafletPip = {
 
         layer.eachLayer(function(l) {
             if (first && results.length) return;
-            console.log(l);
             if ((l.feature.geometry.type === "MultiPolygon" ||
                  l.feature.geometry.type === "Polygon") &&
                 gju.pointInPolygon({


### PR DESCRIPTION
It seems like recent versions of Leaflet do not have L.Polygon and L.MultiPolygon classes. I am however not sure whether the fix I propose is the right way to do it. And maybe it needs additional checks to test whether l.feature exists.

Best regards,
Jesper
