### PR TITLE
fix: remove unneeded uglify-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "author": "Tom MacWright <tom@macwright.org>",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "geojson-utils": "~1.1.0",
-    "uglify-js": "2.7.4"
+    "geojson-utils": "~1.1.0"
   }
 }


### PR DESCRIPTION
`uglify-js` is not used at all by this package and is a very heavy dependency.